### PR TITLE
update windows build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,36 +1,29 @@
+md build
+cd build
 
 :: Hack for winres.h being called winresrc.h on VS2008
 if %VS_MAJOR% LEQ 9 copy %RECIPE_DIR%\winres.h .
+
+cmake -LAH -GNinja ..                                               ^
+  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON                             ^
+  -DBUILD_SHARED_LIBS=ON                                            ^
+  -DCMAKE_BUILD_TYPE=Release                                        ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%                           ^
+  -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%                              ^
+  -DCMAKE_FIND_ROOT_PATH=%LIBRARY_PREFIX%;%PREFIX%;%BUILD_PREFIX%   ^
+  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
 if errorlevel 1 exit 1
 
-:: Build!
-nmake /f Makefile.vc CFG=release-dynamic RTLIBCFG=dynamic OBJDIR=output
+cmake --build .
+if errorlevel 1 exit 1
+cmake --install .
 if errorlevel 1 exit 1
 
-:: Copy the dll's of these dependencies
-copy output\release-dynamic\%ARCH%\bin\cwebp.exe %LIBRARY_PREFIX%\bin\cwebp.exe
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\bin\dwebp.exe %LIBRARY_PREFIX%\bin\dwebp.exe
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\bin\libwebp.dll %LIBRARY_PREFIX%\bin\libwebp.dll
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\bin\libwebpdecoder.dll %LIBRARY_PREFIX%\bin\libwebpdecoder.dll
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\bin\libwebpdemux.dll %LIBRARY_PREFIX%\bin\libwebpdemux.dll
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\lib\libwebp_dll.lib %LIBRARY_PREFIX%\lib\libwebp.lib
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\lib\libwebpdecoder_dll.lib %LIBRARY_PREFIX%\lib\libwebpdecoder.lib
-if errorlevel 1 exit 1
-copy output\release-dynamic\%ARCH%\lib\libwebpdemux_dll.lib %LIBRARY_PREFIX%\lib\libwebpdemux.lib
-if errorlevel 1 exit 1
-
-:: Copy header files
-mkdir %LIBRARY_PREFIX%\include\webp\
-if errorlevel 1 exit 1
-copy src\webp\decode.h %LIBRARY_PREFIX%\include\webp\
-if errorlevel 1 exit 1
-copy src\webp\encode.h %LIBRARY_PREFIX%\include\webp\
-if errorlevel 1 exit 1
-copy src\webp\types.h %LIBRARY_PREFIX%\include\webp\
-if errorlevel 1 exit 1
+:: for backwards compatibility with previous make build. This will fail on non-ntfs systems.
+pushd %LIBRARY_PREFIX%\lib
+:: add a symlink with "lib" prefixed for each lib file
+FOR /F %%G IN ('dir "*webp*lib" /B') DO (MKLINK lib%%G %%G || echo failed to link %%G )
+popd
+pushd %LIBRARY_PREFIX%\bin
+FOR /F %%G IN ('dir "*webp*dll" /B') DO (MKLINK lib%%G %%G || echo failed to link %%G )
+popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_compatible('libwebp-base') }}
@@ -20,6 +20,9 @@ requirements:
     - libtool  # [unix]
     - {{ compiler('c') }}
     - make  # [not win]
+    - ninja # [win]
+    - cmake # [win]
+    - m2-patch # [win]
   run_constrained:
     # 1.1 is when libwebp-base was split from libwebp
     - libwebp {{ version }}
@@ -31,17 +34,17 @@ test:
     - test -f $PREFIX/include/webp/decode.h       # [not win]
     - test -f $PREFIX/include/webp/encode.h       # [not win]
     - test -f $PREFIX/include/webp/types.h        # [not win]
-    - if not exist %LIBRARY_LIB%\\libwebp.lib exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\libwebpdemux.lib exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\libwebpdecoder.lib exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\libwebp.dll exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\libwebpdemux.dll exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\libwebpdecoder.dll exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\cwebp.exe exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\\dwebp.exe exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\webp\\decode.h exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\webp\\encode.h exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\webp\\types.h exit 1  # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\lib\\libwebp.lib exit 1            # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\lib\\libwebpdemux.lib exit 1       # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\lib\\libwebpdecoder.lib exit 1     # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\bin\\libwebp.dll exit 1            # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\bin\\libwebpdemux.dll exit 1       # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\bin\\libwebpdecoder.dll exit 1     # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\bin\\cwebp.exe exit 1              # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\bin\\dwebp.exe exit 1              # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\include\\webp\\decode.h exit 1     # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\include\\webp\\encode.h exit 1     # [win]
+    - if not exist %CONDA_PREFIX%\\Library\\include\\webp\\types.h exit 1      # [win]
 
 about:
   home: https://developers.google.com/speed/webp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ package:
 source:
   url: http://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-{{ version }}.tar.gz
   sha256: 7656532f837af5f4cec3ff6bafe552c044dc39bf453587bd5b77450802f4aee6
+  patches: patches/windows_declspec.patch  # [win]
 
 build:
   number: 1

--- a/recipe/patches/windows_declspec.patch
+++ b/recipe/patches/windows_declspec.patch
@@ -1,0 +1,53 @@
+commit 40733377ca544283d8d0444b3fadf6b08d7020ae
+Author: leej3 <leej3@quansight.com>
+Date:   Mon Mar 14 07:56:18 2022 -0500
+
+    modify imports
+
+diff --git a/examples/cwebp.c b/examples/cwebp.c
+index 927063a..07b67bf 100644
+--- a/examples/cwebp.c
++++ b/examples/cwebp.c
+@@ -34,7 +34,7 @@
+ extern "C" {
+ #endif
+ 
+-extern void* VP8GetCPUInfo;   // opaque forward declaration.
++__declspec(dllimport) extern void* VP8GetCPUInfo;   // opaque forward declaration.
+ 
+ #ifdef __cplusplus
+ }    // extern "C"
+diff --git a/examples/dwebp.c b/examples/dwebp.c
+index 5cfb0fb..ba84a04 100644
+--- a/examples/dwebp.c
++++ b/examples/dwebp.c
+@@ -33,7 +33,7 @@ static int quiet = 0;
+ extern "C" {
+ #endif
+ 
+-extern void* VP8GetCPUInfo;   // opaque forward declaration.
++__declspec(dllimport) extern void* VP8GetCPUInfo;   // opaque forward declaration.
+ 
+ #ifdef __cplusplus
+ }    // extern "C"
+diff --git a/src/dsp/dsp.h b/src/dsp/dsp.h
+index c4f57e4..973e29d 100644
+--- a/src/dsp/dsp.h
++++ b/src/dsp/dsp.h
+@@ -262,6 +262,8 @@ typedef enum {
+ // returns true if the CPU supports the feature.
+ typedef int (*VP8CPUInfo)(CPUFeature feature);
+ WEBP_EXTERN VP8CPUInfo VP8GetCPUInfo;
+ 
+ //------------------------------------------------------------------------------
+ // Init stub generator
+@@ -642,7 +644,8 @@ extern void (*WebPExtractGreen)(const uint32_t* WEBP_RESTRICT argb,
+ // Un-Multiply operation transforms x into x * 255 / A.
+ 
+ // Pre-Multiply or Un-Multiply (if 'inverse' is true) argb values in a row.
+-extern void (*WebPMultARGBRow)(uint32_t* const ptr, int width, int inverse);
++__declspec(dllimport) extern void (*WebPMultARGBRow)(uint32_t* const ptr, int width, int inverse);
++
+ 
+ // Same a WebPMultARGBRow(), but for several rows.
+ void WebPMultARGBRows(uint8_t* ptr, int stride, int width, int num_rows,


### PR DESCRIPTION
This allows me to build opencv against libwebp on Windows (my previous misguided attempt was [here](https://github.com/AnacondaRecipes/libwebp-feedstock/pull/5). It changes the build from nmake to CMake so that .pc and .cmake files are included in the package. To maintain backwards compatibility with other packages linking against library files that are prefixed with "lib" (not something the cmake build does on Windows) I have added symlinks. I believe this will work but correct me if I am wrong.

This PR leaves Unix likes platforms untouched. Let me know if you want me to add that as we could then vendor .cmake files with those builds too. 