### PR TITLE
Update version to 1.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "1.3.2" %}
-{% set major,minor,patch = version.split('.') %}
+{% set version = "1.6.0" %}
+{% set name = "libwebp" %}
 
 package:
-  name: libwebp-base
+  name: {{ name }}-base
   version: {{ version }}
 
 source:
-  url: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-{{ version }}.tar.gz
-  sha256: 2a499607df669e40258e53d0ade8035ba4ec0175244869d1025d460562aa09b4
+  url: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/{{ name }}-{{ version }}.tar.gz
+  sha256: e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564
 
 build:
   number: 1
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - cmake
     - ninja-base
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=libwebp
     - {{ pin_subpackage('libwebp-base') }}


### PR DESCRIPTION
libwebp-base 1.6.0

**Destination channel:** defaults

### Links

- [PKG-10855](https://anaconda.atlassian.net/browse/PKG-10855) 
- [Upstream repository](https://chromium.googlesource.com/webm/libwebp)

### Explanation of changes:

- new version number
- adding stdlib('c') to dependency

[PKG-10855]: https://anaconda.atlassian.net/browse/PKG-10855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ